### PR TITLE
Fixing build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ $(COMPAT_DIR)/compat-5.1.o: $(COMPAT_DIR)/compat-5.1.c
 
 install: src/$(LIBNAME)
 	mkdir -p $(LUA_LIBDIR)
-	cp src/$(LIBNAME) $(LUA_LIBDIR)
-	cd $(LUA_LIBDIR); ln -f -s $(LIBNAME) $T.so
+	cp src/$(LIBNAME) $(LUA_LIBDIR)/$T.so
+	#cd $(LUA_LIBDIR); ln -f -s $(LIBNAME) $T.so
 
 clean:
 	rm -f $L src/$(LIBNAME) $(OBJS)

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ $(COMPAT_DIR)/compat-5.1.o: $(COMPAT_DIR)/compat-5.1.c
 install: src/$(LIBNAME)
 	mkdir -p $(LUA_LIBDIR)
 	cp src/$(LIBNAME) $(LUA_LIBDIR)/$T.so
-	#cd $(LUA_LIBDIR); ln -f -s $(LIBNAME) $T.so
 
 clean:
 	rm -f $L src/$(LIBNAME) $(OBJS)

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-LuaZip 1.2.3
+LuaZip 1.2.4
 ------------
 
 LuaZip is a lightweight Lua extension library used to read files stored inside zip files.

--- a/doc/us/index.html
+++ b/doc/us/index.html
@@ -64,7 +64,7 @@ Lua I/O library API.</p>
 
 <h2><a name="status"></a>Status</h2>
 
-<p>Current version is 1.2.3. It was developed for Lua 5.0 and 5.1.</p>
+<p>Current version is 1.2.4. It was developed for Lua 5.0 and 5.1.</p>
 
 <h2><a name="download"></a>Download</h2>
 
@@ -76,6 +76,9 @@ a Windows binary version of LuaZip can be found at the same LuaForge page.</p>
 <h2><a name="history"></a>History</h2>
 
 <dl class="history">
+	<dt><strong>Version 1.2.4</strong> [09/Jun/2014]</dt>
+    <dd>Fixed Makefile to work with LuaRocks.</dd>
+	
     <dt><strong>Version 1.2.3</strong> [18/Jun/2007]</dt>
     <dd>Adapted to work on both Lua 5.0 and Lua 5.1.</dd>
 

--- a/rockspec/luazip-1.2.4-1.rockspec
+++ b/rockspec/luazip-1.2.4-1.rockspec
@@ -1,0 +1,35 @@
+package = "LuaZip"
+version = "1.2.4-1"
+source = {
+   url = "git://github.com/rjpcomputing/luazip",
+   tag = "v1_2_4"
+}
+description = {
+   summary = "Library for reading files inside zip files",
+   detailed = [[
+      LuaZip is a lightweight Lua extension library used to read files
+      stored inside zip files. The API is very similar to the standard
+      Lua I/O library API.
+   ]],
+   homepage = "http://github.com/rjpcomputing/luazip",
+   license = "MIT"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   ZZIP = {
+      header = "zzip.h",
+   },
+}
+build = {
+   type = "builtin",
+   modules = {
+      zip = {
+         sources = "src/luazip.c",
+         libraries = {"zzip"},
+         libdirs = {"$(ZZIP_LIBDIR)"},
+         incdirs = {"$(ZZIP_INCDIR)"},
+      }
+   }
+}

--- a/rockspec/luazip-1.2.4-2.rockspec
+++ b/rockspec/luazip-1.2.4-2.rockspec
@@ -1,0 +1,82 @@
+package = "LuaZip"
+version = "1.2.4-2"
+source = {
+   url = "git://github.com/rjpcomputing/luazip",
+   tag = "v1_2_4"
+}
+description = {
+   summary = "Library for reading files inside zip files",
+   detailed = [[
+      LuaZip is a lightweight Lua extension library used to read files
+      stored inside zip files. The API is very similar to the standard
+      Lua I/O library API.
+   ]],
+   homepage = "http://github.com/rjpcomputing/luazip",
+   license = "MIT"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+external_dependencies = {
+   ZZIP = {
+      header = "zzip.h",
+   },
+}
+build = {
+   type = "builtin",
+   modules = {
+      zip = {
+         sources = "src/luazip.c",
+         libraries = {"zzip"},
+         libdirs = {"$(ZZIP_LIBDIR)"},
+         incdirs = {"$(ZZIP_INCDIR)"},
+      }
+   },
+   patches = {
+[[
+--- luazip/src/luazip.c	2016-07-28 19:34:08.695472558 -0300
++++ luazip/src/luazip.c	2016-07-28 19:34:13.620472470 -0300
+@@ -21,6 +21,40 @@
+ #define ZIPINTERNALFILEHANDLE  "lzipInternalFile"
+ #define LUAZIP_MAX_EXTENSIONS 32
+ 
++#ifndef luaL_reg
++#define luaL_reg luaL_Reg
++#endif
++#ifndef luaL_getn
++#define luaL_getn luaL_len
++#endif
++#ifndef lua_strlen
++#define lua_strlen luaL_len
++#endif
++#ifndef luaL_optlong
++#define luaL_optlong luaL_optinteger
++#endif
++#if LUA_VERSION_NUM >= 501
++#if LUA_VERSION_NUM == 501
++/* From https://github.com/keplerproject/lua-compat-5.2/blob/v0.3/c-api/compat-5.2.c */
++void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup) {
++  luaL_checkstack(L, nup+1, "too many upvalues");
++  for (; l->name != NULL; l++) {  /* fill the table with given functions */
++    int i;
++    lua_pushstring(L, l->name);
++    for (i = 0; i < nup; i++)  /* copy upvalues to the top */
++      lua_pushvalue(L, -(nup + 1));
++    lua_pushcclosure(L, l->func, nup);  /* closure with those upvalues */
++    lua_settable(L, -(nup + 3)); /* table must be below the upvalues, the name and the closure */
++  }
++  lua_pop(L, nup);  /* remove upvalues */
++}
++#endif
++static void luaL_openlib(lua_State *L, const char* name, const luaL_Reg* lib, int nup) {
++  lua_newtable(L); luaL_setfuncs(L, lib, nup);
++  if (name) { lua_pushvalue(L, -1); lua_setglobal(L, name); }
++}
++#endif
++
+ static int pushresult (lua_State *L, int i, const char *filename) {
+   if (i) {
+     lua_pushboolean(L, 1);
+]]
+   }
+}

--- a/rockspec/luazip-1.2.4-2.rockspec
+++ b/rockspec/luazip-1.2.4-2.rockspec
@@ -68,10 +68,12 @@ build = {
 +  lua_pop(L, nup);  /* remove upvalues */
 +}
 +#endif
++#ifndef LUA_COMPAT_OPENLIB
 +static void luaL_openlib(lua_State *L, const char* name, const luaL_Reg* lib, int nup) {
 +  lua_newtable(L); luaL_setfuncs(L, lib, nup);
 +  if (name) { lua_pushvalue(L, -1); lua_setglobal(L, name); }
 +}
++#endif
 +#endif
 +
  static int pushresult (lua_State *L, int i, const char *filename) {

--- a/src/luazip.c
+++ b/src/luazip.c
@@ -511,7 +511,7 @@ static void set_info (lua_State *L) {
 	lua_pushliteral (L, "Reading files inside zip files");
 	lua_settable (L, -3);
 	lua_pushliteral (L, "_VERSION");
-	lua_pushliteral (L, "LuaZip 1.2.3");
+	lua_pushliteral (L, "LuaZip 1.2.4");
 	lua_settable (L, -3);
 }
 


### PR DESCRIPTION
Fixed build error

```
Installing https://rocks.moonscript.org/luazip-1.2.4-2.src.rock...
Using https://rocks.moonscript.org/luazip-1.2.4-2.src.rock... switching to 'build' mode
Applying patch 1...
successfully patched src/luazip.c
gcc -O2 -fPIC -I/usr/include/lua5.1 -c src/luazip.c -o src/luazip.o -I/usr/include
src/luazip.c:52:13: error: static declaration of ‘luaL_openlib’ follows non-static declaration
 static void luaL_openlib(lua_State *L, const char* name, const luaL_Reg* lib, int nup) {
             ^
In file included from src/luazip.c:15:0:
/usr/include/lua5.1/lauxlib.h:27:22: note: previous declaration of ‘luaL_openlib’ was here
 #define luaI_openlib luaL_openlib
                      ^
/usr/include/lua5.1/lauxlib.h:42:18: note: in expansion of macro ‘luaI_openlib’
 LUALIB_API void (luaI_openlib) (lua_State *L, const char *libname,
                  ^

Error: Build error: Failed compiling object src/luazip.o
```
